### PR TITLE
fix: mcp config and duplicate hooks issue

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,6 @@
   "version": "1.0.0",
   "description": "Comprehensive Rust development assistant with meta-question routing, coding guidelines, version queries, and ecosystem support",
   "skills": "./skills/",
-  "hooks": "./hooks/hooks.json",
   "author": {
     "name": "CoRust",
     "email": "corust@example.com"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,8 @@
 {
-  "actionbook": {
-    "command": "npx",
-    "args": ["-y", "@actionbookdev/mcp@latest"]
+  "mcpServers": {
+    "actionbook": {
+      "command": "npx",
+      "args": ["-y", "@actionbookdev/mcp@latest"]
+    }
   }
 }


### PR DESCRIPTION
## Summary                                                                                           
                                                                                                       
  Fix plugin loading errors when using `claude --plugin-dir`:                                          
                                                                                                       
  1. **MCP config schema error** - Wrap server definitions in required `mcpServers` key                
  2. **Duplicate hooks error** - Remove explicit hooks reference (auto-loaded by Claude Code)          
                                                                                                       
  ## Problem                                                                                           
                                                                                                       
  Running `claude --plugin-dir /path/to/rust-skills` produces:                                         
                                                                                                       
  [Error] mcpServers: Does not adhere to MCP server configuration schema                               
                                                                                                       
  Duplicate hooks file detected: ./hooks/hooks.json resolves to already-loaded file                    

## Screenshot

<img width="845" height="722" alt="image" src="https://github.com/user-attachments/assets/cb076344-ec86-42e8-bd14-5c0cbee52592" />
                                                                                                       
  ## Changes                                                                                           
                                                                                                       
  | File | Change |                                                                                    
  |------|--------|                                                                                    
  | `.mcp.json` | Wrap config in `mcpServers` key (required by Claude Code) |                          
  | `.claude-plugin/plugin.json` | Remove `"hooks": "./hooks/hooks.json"` (auto-loaded) |              
                                                                                                       
  ## Test                                                                                              
                                                                                                       
  ```bash                                                                                              
  claude --plugin-dir /path/to/rust-skills                                                             
  # No plugin errors should appear
```
