### PR TITLE
fix: use HTTPS URL for marketplace installation

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -52,7 +52,7 @@ Claude Code プラグインマーケットプレイスから2ステップでイ�
 
 ```bash
 # ステップ 1: marketplace を追加
-/plugin marketplace add ZhangHanDong/rust-skills
+/plugin marketplace add https://github.com/ZhangHanDong/rust-skills
 
 # ステップ 2: プラグインをインストール
 /plugin install rust-skills@rust-skills

--- a/README-zh.md
+++ b/README-zh.md
@@ -52,7 +52,7 @@ AI (使用 Rust Skills):
 
 ```bash
 # 步骤 1: 添加 marketplace
-/plugin marketplace add ZhangHanDong/rust-skills
+/plugin marketplace add https://github.com/ZhangHanDong/rust-skills
 
 # 步骤 2: 安装插件
 /plugin install rust-skills@rust-skills

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Install from Claude Code Plugin Marketplace in two steps:
 
 ```bash
 # Step 1: Add the marketplace
-/plugin marketplace add ZhangHanDong/rust-skills
+/plugin marketplace add https://github.com/ZhangHanDong/rust-skills
 
 # Step 2: Install the plugin
 /plugin install rust-skills@rust-skills


### PR DESCRIPTION
## Summary

This PR changes the marketplace installation command from SSH shorthand to HTTPS URL to avoid authentication error:

```bash
 ▐▛███▜▌   Claude Code v2.1.15                                                                                                                    
▝▜█████▛▘  Opus 4.5 · Claude Max                                                                                                                                                                                                                   
                                                                                                                                                  
❯ /plugin marketplace add ZhangHanDong/rust-skills                                                                                                
  ⎿  Error: Failed to clone marketplace repository: SSH authentication failed. Please ensure your SSH keys are configured for GitHub, or use an   
     HTTPS URL instead.                                                                                                                           
                                                                                                                                                  
     Original error: Cloning into '/Users/lyy/.claude/plugins/marketplaces/ZhangHanDong-rust-skills'...                                           
     ERROR: upstream connect error or disconnect/reset before headers. retried and the latest reset reason: remote connection failure, transport  
     failure reason: delayed connect error: Connection refused                                                                                    
     fatal: Could not read from remote repository.                                                                                                
                                                                                                                                                  
     Please make sure you have the correct access rights                                                                                          
     and the repository exists.  
```

## Test

```bash
❯ /plugin marketplace add https://github.com/ZhangHanDong/rust-skills                                                                             
  ⎿  Successfully added marketplace: rust-skills 
```