### PR TITLE
docs: fix OpenCode installation instructions

### DIFF
--- a/.opencode/INSTALL.md
+++ b/.opencode/INSTALL.md
@@ -4,117 +4,187 @@
 
 ## Installation
 
-### Method 1: Instructions Configuration (Recommended)
+Rust Skills provides 38+ individual skills (located in `skills/*/SKILL.md`) that OpenCode loads on-demand. This is different from instructions - skills are loaded only when needed, saving context tokens.
 
-Add rust-skills as instructions in your OpenCode config:
+### Method 1: Direct Clone (Recommended)
 
-**Step 1:** Clone the repository
+Clone the repository directly into a skills directory for automatic updates via `git pull`:
+
+#### Option A: Agent-Compatible Location (Highest Compatibility) ⭐
+
+Works with OpenCode, Claude Code, and other AI coding agents:
 
 ```bash
+# Create directory if it doesn't exist
+mkdir -p ~/.agents/skills
+
+# Clone directly
+cd ~/.agents/skills
+git clone https://github.com/ZhangHanDong/rust-skills.git
+```
+
+This creates: `~/.agents/skills/rust-skills/skills/*/SKILL.md`
+
+OpenCode will discover all 38 skills automatically.
+
+#### Option B: Claude-Compatible Location
+
+For Claude Code compatibility:
+
+```bash
+mkdir -p ~/.claude/skills
+cd ~/.claude/skills
+git clone https://github.com/ZhangHanDong/rust-skills.git
+```
+
+#### Option C: OpenCode-Specific Location
+
+OpenCode-only installation:
+
+```bash
+mkdir -p ~/.config/opencode/skills
+cd ~/.config/opencode/skills
+git clone https://github.com/ZhangHanDong/rust-skills.git
+```
+
+### Method 2: Copy Skills (Flat Structure)
+
+Copy individual skills to the same directory level (no intermediate `rust-skills` folder):
+
+#### Global Installation
+
+```bash
+# Clone the repository
 git clone https://github.com/ZhangHanDong/rust-skills.git ~/rust-skills
+
+# Copy to agent-compatible location (recommended)
+mkdir -p ~/.agents/skills
+cp -r ~/rust-skills/skills/* ~/.agents/skills/
+
+# OR copy to Claude-compatible location
+mkdir -p ~/.claude/skills
+cp -r ~/rust-skills/skills/* ~/.claude/skills/
+
+# OR copy to OpenCode-specific location
+mkdir -p ~/.config/opencode/skills
+cp -r ~/rust-skills/skills/* ~/.config/opencode/skills/
 ```
 
-**Step 2:** Add to your OpenCode configuration
-
-Edit `~/.config/opencode/opencode.json` (or `.opencode/opencode.json` in your project):
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "instructions": [
-    "~/rust-skills/.opencode/instructions/rust-skills.md"
-  ]
-}
-```
-
-### Method 2: Copy Instructions to Global Config
+#### Project-Level Installation
 
 ```bash
-# Clone rust-skills
+# From your Rust project root
 git clone https://github.com/ZhangHanDong/rust-skills.git
 
-# Create OpenCode instructions directory
-mkdir -p ~/.config/opencode/instructions
+# Copy to project directory
+mkdir -p .agents/skills
+cp -r rust-skills/skills/* .agents/skills/
 
-# Copy instruction files
-cp rust-skills/.opencode/instructions/*.md ~/.config/opencode/instructions/
+# OR use .opencode/skills/
+mkdir -p .opencode/skills
+cp -r rust-skills/skills/* .opencode/skills/
 ```
 
-Then add to your config:
+by opencode doc
+https://opencode.ai/docs/skills/
+all the paths below is valid
+    Project config: .opencode/skills//SKILL.md
+    Global config: ~/.config/opencode/skills//SKILL.md
+    Project Claude-compatible: .claude/skills//SKILL.md
+    Global Claude-compatible: ~/.claude/skills//SKILL.md
+    Project agent-compatible: .agents/skills//SKILL.md
+    Global agent-compatible: ~/.agents/skills//SKILL.md
 
-```json
-{
-  "instructions": [
-    "~/.config/opencode/instructions/rust-skills.md"
-  ]
-}
-```
 
-### Method 3: Project-Level Instructions
-
-For per-project usage, create `.opencode/opencode.json` in your Rust project:
-
-```json
-{
-  "$schema": "https://opencode.ai/config.json",
-  "instructions": [
-    "~/rust-skills/.opencode/instructions/rust-skills.md"
-  ]
-}
-```
 
 ## Verification
 
-After installation, test by asking OpenCode:
+After installation, verify that skills are discoverable:
+
+```bash
+# Start OpenCode in a Rust project
+cd /path/to/rust/project
+opencode
+
+# In OpenCode, check available skills
+/skills
+```
+
+You should see rust-skills in the list, including:
+- `rust-router` - Master router for Rust questions
+- `rust-learner` - Fetch Rust/crate version info
+- `m01-ownership` through `m15-anti-pattern` - Meta-question skills
+- `domain-*` - Domain-specific skills (fintech, ml, web, etc.)
+- And many more...
+
+### Testing a Skill
+
+Try asking a Rust question:
 
 ```
 How do I fix E0382 in Rust?
 ```
 
-Expected: OpenCode should reference ownership concepts and provide Rust-specific guidance.
+OpenCode should automatically discover and load the appropriate skill (likely `rust-router` which will then route to `m01-ownership`).
 
-## What's Included
+You can also explicitly load a skill:
 
-The rust-skills instructions provide:
-
-- **Rust Coding Guidelines**: Naming conventions, formatting rules, best practices
-- **Error Code Reference**: E0382, E0597, E0277, etc. with explanations
-- **Meta-Question Skills**: Ownership, concurrency, error handling patterns
-- **Default Project Settings**: Recommended Cargo.toml configurations
-
-## Configuration Reference
-
-| Config Location | Scope |
-|-----------------|-------|
-| `~/.config/opencode/opencode.json` | Global (all projects) |
-| `.opencode/opencode.json` | Project-specific |
+```
+/skill rust-router
+```
 
 ## Troubleshooting
 
-### Instructions not loading?
+### Skills not showing up?
 
-1. Verify the path exists:
-   ```bash
-   ls ~/rust-skills/.opencode/instructions/
-   ```
+1. **Verify the path exists:**
+2. **Check skill structure:**
+3. **Verify SKILL.md format:**
+4. **Verify SKILL.md are all capitalized**
+5. **Restart OpenCode** after installation
 
-2. Check config syntax:
-   ```bash
-   cat ~/.config/opencode/opencode.json | jq .
-   ```
+### Skills not loading automatically?
 
-3. Restart OpenCode after config changes
+OpenCode loads skills on-demand when it detects relevant context. You can explicitly load a skill:
 
-### Path expansion issues?
-
-Use absolute paths instead of `~`:
-```json
-{
-  "instructions": [
-    "/Users/yourname/rust-skills/.opencode/instructions/rust-skills.md"
-  ]
-}
 ```
+/skill rust-router
+```
+
+Or ask a question that triggers skill loading:
+
+```
+How do I handle E0382?
+```
+
+## Configuration Reference
+
+### Config Location
+
+| Config File | Scope |
+|-------------|-------|
+| `~/.config/opencode/opencode.json` | Global (all projects) |
+| `.opencode/opencode.json` | Project-specific |
+
+
+## Updating Skills
+
+```bash
+cd ~/.agents/skills/rust-skills
+git pull
+```
+## Uninstallation
+
+```bash
+rm -rf ~/.agents/skills/rust-skills
+```
+
+## Why ~/.agents/skills/ is Recommended
+
+1. **Highest Compatibility**: Works with OpenCode, Claude Code, and other AI coding agents
+2. **Industry Standard**: `.agents/` is becoming the cross-agent standard directory
+3. **No Vendor Lock-in**: Switch between different AI coding tools without reinstalling
+4. **Future-Proof**: New agents are likely to support `.agents/` directory
 
 ## Limitations
 
@@ -132,5 +202,7 @@ OpenCode integration provides instruction-based guidance only. Features requirin
 ## Links
 
 - [OpenCode Documentation](https://opencode.ai/docs/)
+- [OpenCode Skills Guide](https://opencode.ai/docs/skills/)
 - [OpenCode Config Reference](https://opencode.ai/docs/config/)
 - [Rust Skills GitHub](https://github.com/ZhangHanDong/rust-skills)
+- [Rust Skills Architecture](https://github.com/ZhangHanDong/rust-skills/blob/main/docs/architecture-zh.md)


### PR DESCRIPTION
- Remove incorrect instructions configuration methods
- Add direct clone and copy methods for skills
- Prioritize ~/.agents/skills/ as highest compatibility location
- Include all 6 valid skill paths from OpenCode docs
- Add verification commands and troubleshooting guide

fix #6 