### PR TITLE
docs: reduce Claude/Codex behavior drift with a shared platform contract

### DIFF
--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -11,7 +11,7 @@ Copy the main agent instructions to your project:
 cp AGENTS.md /path/to/your/project/AGENTS.md
 ```
 
-This is the lightest install path. It gives Codex the required Rust workflow summary, but not the full repository context.
+This is the lightest install path. It gives Codex a useful Rust workflow summary and standalone quick reference, but not the full repository context or the closest Claude parity.
 
 ### Option 2: Reference as Submodule
 
@@ -52,6 +52,7 @@ What parity does not mean:
 - automatic prompt-submit hook injection
 - identical runtime tool APIs
 - identical enforcement strength
+- guaranteed live-data retrieval when the required tools are unavailable
 
 ## What's Included
 

--- a/.codex/INSTALL.md
+++ b/.codex/INSTALL.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-### Option 1: Copy AGENTS.md
+### Option 1: Copy AGENTS.md (Minimal)
 
 Copy the main agent instructions to your project:
 
@@ -10,6 +10,8 @@ Copy the main agent instructions to your project:
 # From the rust-skills repository
 cp AGENTS.md /path/to/your/project/AGENTS.md
 ```
+
+This is the lightest install path. It gives Codex the required Rust workflow summary, but not the full repository context.
 
 ### Option 2: Reference as Submodule
 
@@ -26,6 +28,31 @@ Then reference in your AGENTS.md:
 See `.rust-skills/AGENTS.md` for Rust development guidelines.
 ```
 
+This is the recommended option for the closest behavior parity with Claude Code because Codex can also read:
+- the skill files
+- the `_meta/` documents
+- the rest of the repository guidance
+
+## Behavior Parity With Claude Code
+
+Codex does not support the Claude Code plugin hook flow used by this repository.
+
+To get the closest behavior:
+- use `AGENTS.md` as the Codex entry point
+- keep the repository available locally if possible so Codex can read the skills and `_meta/` guidance
+- if you installed via submodule or local checkout, follow the shared behavior contract in [`_meta/platform-behavior-contract.md`](../_meta/platform-behavior-contract.md)
+
+What parity means here:
+- same routing intent
+- same negotiation rules
+- same domain-aware skill loading
+- same `rust-learner` path for live information
+
+What parity does not mean:
+- automatic prompt-submit hook injection
+- identical runtime tool APIs
+- identical enforcement strength
+
 ## What's Included
 
 This plugin provides Rust development assistance:
@@ -38,7 +65,13 @@ This plugin provides Rust development assistance:
 
 ## Usage
 
-After installation, ask Codex about:
+After installation, Codex should:
+- read `AGENTS.md`
+- apply the shared workflow described in `AGENTS.md`
+- if the repository is available locally, also apply the shared contract from `_meta/platform-behavior-contract.md`
+- route Rust prompts through `rust-router` before specialized skills
+
+Then you can ask Codex about:
 
 - Rust ownership and borrowing
 - Error handling patterns
@@ -51,19 +84,6 @@ After installation, ask Codex about:
 - Rust 1.85+ (edition 2024 recommended)
 - Cargo
 
-## Default Project Settings
+## Shared Defaults
 
-When creating Rust projects, use:
-
-```toml
-[package]
-edition = "2024"
-rust-version = "1.85"
-
-[lints.rust]
-unsafe_code = "warn"
-
-[lints.clippy]
-all = "warn"
-pedantic = "warn"
-```
+Use the shared Rust defaults documented in [`_meta/platform-behavior-contract.md`](../_meta/platform-behavior-contract.md#shared-rust-defaults).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,81 @@
 # Rust Skills - Agent Instructions
 
-> For OpenAI Codex and compatible agents
+> Codex and compatible-agent adapter for the shared Rust behavior contract.
+> If this repository is available locally, also read [`_meta/platform-behavior-contract.md`](_meta/platform-behavior-contract.md).
+> If `AGENTS.md` is copied standalone into another project, the required Codex workflow is summarized here.
 
-## Default Project Settings
+## Codex Operating Model
 
-When creating Rust projects or Cargo.toml files, ALWAYS use:
+Codex does not use the Claude plugin hook model from this repository.
+
+That means behavior parity with Claude comes from following the same contract explicitly:
+- route through `rust-router` first
+- enable negotiation when comparison or synthesis is required
+- load both mechanics/design skills and `domain-*` skills when domain context matters
+- use `rust-learner` for live Rust/crate/docs questions
+
+## Required Codex Workflow
+
+### 1. Start With `rust-router`
+
+For any Rust-related question, invoke `rust-router` before jumping to specialized skills.
+
+This includes:
+- compiler errors such as `E0382`, `E0277`, `E0597`
+- design and best-practice questions
+- crate and ecosystem questions
+- code-writing requests in Rust
+
+### 2. Trigger Negotiation Explicitly
+
+When the user asks for:
+- comparisons
+- trade-offs
+- best practices
+- domain + error synthesis
+
+Codex should treat the prompt as a negotiation query and follow the shared output contract for confidence, gaps, and recommendation.
+
+### 3. Load Both Domain and Mechanics Skills When Needed
+
+Do not stop at the first technical keyword when domain context changes the correct answer.
+
+Examples:
+- `Web API` + `Send` -> `m07-concurrency` + `domain-web`
+- `trading` + `E0382` -> `m01-ownership` + `domain-fintech`
+
+### 4. Use `rust-learner` for Live Information
+
+For:
+- Rust version features
+- crate versions and metadata
+- API docs
+- Clippy lint lookups
+
+prefer `rust-learner` and its agent or inline workflows over answering from memory.
+
+## Codex Expectations
+
+### Behavior Parity
+
+Codex should aim for the same reasoning behavior as Claude:
+- same routing intent
+- same negotiation triggers
+- same dual-skill loading rules
+- same output expectations
+
+### Capability Difference
+
+Codex does not automatically receive the plugin hook injection that Claude gets from `.claude/hooks/`.
+
+So Codex parity is achieved through:
+- these instructions
+- the shared contract
+- the skill files themselves
+
+## Shared Rust Defaults
+
+When creating Rust projects or `Cargo.toml` files, use:
 
 ```toml
 [package]
@@ -19,94 +90,15 @@ all = "warn"
 pedantic = "warn"
 ```
 
-## Core Capabilities
+## Key Skill Entry Points
 
-### 1. Question Routing
-Route Rust questions to appropriate skills:
-- Ownership/borrowing → m01-ownership
-- Smart pointers → m02-resource
-- Error handling → m06-error-handling
-- Concurrency → m07-concurrency
-- Unsafe code → unsafe-checker
+If the repository is available locally:
 
-### 2. Code Style
-Follow Rust coding guidelines:
-- Use snake_case for variables and functions
-- Use PascalCase for types and traits
-- Use SCREAMING_SNAKE_CASE for constants
-- Max line length: 100 characters
-- Use `?` operator instead of `unwrap()` in library code
+- `skills/rust-router/SKILL.md` - master routing
+- `skills/rust-learner/SKILL.md` - live Rust/crate/docs queries
+- `skills/coding-guidelines/SKILL.md` - style and conventions
+- `skills/unsafe-checker/SKILL.md` - unsafe and FFI guidance
 
-### 3. Error Handling
-```rust
-// Good: Use Result with context
-fn read_config() -> Result<Config, ConfigError> {
-    let content = std::fs::read_to_string("config.toml")
-        .map_err(|e| ConfigError::Io(e))?;
-    toml::from_str(&content)
-        .map_err(|e| ConfigError::Parse(e))
-}
+## Practical Rule
 
-// Avoid: unwrap() in library code
-fn read_config() -> Config {
-    let content = std::fs::read_to_string("config.toml").unwrap(); // Bad
-    toml::from_str(&content).unwrap() // Bad
-}
-```
-
-### 4. Unsafe Code
-Every `unsafe` block MUST have a `// SAFETY:` comment:
-```rust
-// SAFETY: We checked that index < len above, so this is in bounds
-unsafe { slice.get_unchecked(index) }
-```
-
-### 5. Common Error Fixes
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| E0382 | Use of moved value | Clone, borrow, or use reference |
-| E0597 | Lifetime too short | Extend lifetime or restructure |
-| E0502 | Borrow conflict | Split borrows or use RefCell |
-| E0499 | Multiple mut borrows | Restructure to single mut borrow |
-| E0277 | Missing trait impl | Add trait bound or implement trait |
-
-## Quick Reference
-
-### Ownership
-- Each value has one owner
-- Borrowing: `&T` (shared) or `&mut T` (exclusive)
-- Lifetimes: `'a` annotations for references
-
-### Smart Pointers
-- `Box<T>`: Heap allocation
-- `Rc<T>`: Reference counting (single-threaded)
-- `Arc<T>`: Atomic reference counting (thread-safe)
-- `RefCell<T>`: Interior mutability
-
-### Concurrency
-- `Send`: Safe to transfer between threads
-- `Sync`: Safe to share references between threads
-- `Mutex<T>`: Mutual exclusion
-- `RwLock<T>`: Reader-writer lock
-
-### Async
-```rust
-#[tokio::main]
-async fn main() {
-    let handle = tokio::spawn(async {
-        // async work
-    });
-    handle.await.unwrap();
-}
-```
-
-## Skill Files
-
-For detailed guidance, see:
-- `skills/rust-router/SKILL.md` - Question routing
-- `skills/coding-guidelines/SKILL.md` - Code style rules
-- `skills/unsafe-checker/SKILL.md` - Unsafe code review
-- `skills/m01-ownership/SKILL.md` - Ownership concepts
-- `skills/m06-error-handling/SKILL.md` - Error patterns
-- `skills/m07-concurrency/SKILL.md` - Concurrency patterns
+If Claude would rely on hooks to force the Rust Skills workflow, Codex should apply that workflow deliberately from these instructions instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,36 @@ all = "warn"
 pedantic = "warn"
 ```
 
+## Standalone Quick Reference
+
+This section intentionally duplicates a small amount of guidance so the documented "copy `AGENTS.md` only" install path remains useful.
+
+### Routing Summary
+
+- ownership / borrow / lifetime / `E0382` / `E0597` -> `m01-ownership`
+- `Box` / `Rc` / `Arc` / smart pointers -> `m02-resource`
+- `Result` / `panic` / error handling -> `m06-error-handling`
+- `async` / `await` / `Send` / `Sync` -> `m07-concurrency`
+- versions / crate info / docs -> `rust-learner`
+- `unsafe` / FFI / raw pointers -> `unsafe-checker`
+
+### Common Error Fixes
+
+| Error | Cause | Fix Direction |
+|---|---|---|
+| `E0382` | use of moved value | borrow, clone intentionally, or redesign ownership |
+| `E0597` | lifetime too short | extend lifetime or restructure borrows |
+| `E0502` | borrow conflict | split borrows or change borrowing pattern |
+| `E0499` | multiple mutable borrows | restructure to one mutable borrow at a time |
+| `E0277` | missing trait bound | add the right bound or use the correct thread-safe type |
+
+### Practical Rust Rules
+
+- Use `?` instead of `unwrap()` in library-style code.
+- Every `unsafe` block needs a `// SAFETY:` comment.
+- Prefer `Arc<T>` over `Rc<T>` when state may cross threads.
+- For read-only functions, prefer `&T` over taking ownership.
+
 ## Key Skill Entry Points
 
 If the repository is available locally:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,154 +1,53 @@
 # Rust Skills - Claude Instructions
 
-## CRITICAL: Negotiation Protocol Check (BEFORE ANY SKILL)
+> Claude Code adapter for the shared Rust behavior contract.
+> Read [`_meta/platform-behavior-contract.md`](_meta/platform-behavior-contract.md) for the cross-platform workflow and output expectations.
 
-**STOP! Before loading ANY skill, check if negotiation is required:**
+## Claude-Specific Role
 
-| Query Contains | Action |
-|----------------|--------|
-| "比较", "对比", "compare", "vs", "versus", "区别", "difference" | **MUST invoke rust-router FIRST** |
-| "最佳实践", "best practice", "推荐", "recommend" | **MUST invoke rust-router FIRST** |
-| Domain keyword + error (e.g., "交易系统 E0382", "web API Send") | **MUST invoke rust-router FIRST** |
-| Two or more technologies (e.g., "tokio 和 async-std") | **MUST invoke rust-router FIRST** |
+Claude Code is the only integration in this repository with:
+- plugin manifests
+- prompt-submit hooks
+- command-based runtime injection
 
-**When negotiation is required, your response MUST include:**
+That means Claude can enforce the shared Rust Skills behavior proactively instead of relying only on static instructions.
 
-```markdown
-## Negotiation Analysis
+## Runtime Enforcement
 
-**Query Type:** [Comparative | Cross-domain | Synthesis | Ambiguous]
-**Negotiation:** Enabled
+When the plugin is installed, Claude should follow the shared contract through:
+- [`hooks/hooks.json`](hooks/hooks.json)
+- [`.claude/hooks/rust-skill-eval-hook.sh`](.claude/hooks/rust-skill-eval-hook.sh)
+- [`skills/rust-router/SKILL.md`](skills/rust-router/SKILL.md)
 
-### Source Assessment
-[For each information source:]
-- **Confidence:** HIGH | MEDIUM | LOW | UNCERTAIN
-- **Gaps:** [What's missing]
-- **Coverage:** [X]%
+The hook layer exists to reinforce three behaviors from the shared contract:
+- `rust-router` first
+- negotiation before specialized answers when comparison or synthesis is required
+- dual-skill loading when domain context changes the right Rust answer
 
-## Synthesized Answer
-[Your answer]
+## Claude Priorities
 
-**Overall Confidence:** [Level]
-**Disclosed Gaps:** [What user should know is missing]
-```
+### 1. Apply the Shared Contract Automatically
 
-**DO NOT skip directly to tokio-basics, ratatui-*, or other specialized skills for comparison queries!**
+If the prompt matches the hook trigger set, do not wait for the user to explicitly ask for routing or negotiation. Apply the shared contract automatically.
 
----
+### 2. Prefer Agent Mode When Available
 
-## CRITICAL: Rust-Router First
+For live data requests, Claude should prefer repository agents such as:
+- `rust-changelog`
+- `crate-researcher`
+- `docs-researcher`
+- `clippy-researcher`
 
-**For ANY Rust-related question, ALWAYS invoke `rust-router` skill FIRST.**
+If the agent path is unavailable, follow the skill's inline fallback path instead of abandoning the contract.
 
-This is NON-NEGOTIABLE. Do NOT:
-- Use WebSearch for Rust questions
-- Answer from memory without invoking skill
-- Skip to specialized skills without checking router
+### 3. Keep Claude-Specific Enforcement Out of Shared Docs
 
-### What Triggers Rust-Router?
+`CLAUDE.md` should describe hook-driven enforcement and Claude runtime behavior.
 
-ANY question containing:
-- Rust, cargo, crate, rustc, Cargo.toml
-- Question words + Rust context
-- Error codes: E0XXX
-- Code writing requests in Rust
-- ANY question while in a Rust project (*.rs, Cargo.toml)
+Shared Rust logic belongs in:
+- [`_meta/platform-behavior-contract.md`](_meta/platform-behavior-contract.md)
+- [`skills/rust-router/SKILL.md`](skills/rust-router/SKILL.md)
 
-### Workflow
+## Default Rust Settings
 
-```
-User Question
-     |
-[1] Invoke: Skill(rust-router)
-     |
-[2] Read rust-router content -> Identify category (m01-m15, etc.)
-     |
-[3] Invoke specialized skill if needed (e.g., m01-ownership)
-     |
-[4] Answer based on skill knowledge
-```
-
-## Routing Table (in rust-router)
-
-| User Intent | Route To |
-|-------------|----------|
-| ownership/borrow/lifetime/E0382/E0597 | m01-ownership |
-| Box/Rc/Arc/smart pointers | m02-resource |
-| mut/Cell/RefCell/interior mutability | m03-mutability |
-| generic/trait/E0277/E0308 | m04-zero-cost |
-| newtype/type state/PhantomData | m05-type-driven |
-| Result/Option/error handling/panic | m06-error-handling |
-| async/await/concurrency/thread/Send/Sync | m07-concurrency |
-| unsafe/FFI/raw pointer | unsafe-checker |
-| domain model/DDD | m09-domain |
-| performance/benchmark | m10-performance |
-| crate/dependency/ecosystem | m11-ecosystem |
-| RAII/Drop/resource lifecycle | m12-lifecycle |
-| domain error/retry/circuit breaker | m13-domain-error |
-| learning Rust/mental model/why | m14-mental-model |
-| anti-pattern/code smell/common mistakes | m15-anti-pattern |
-| Rust version/crate version/latest features | rust-learner |
-| code style/naming/clippy | coding-guidelines |
-| tokio related | tokio-* skills |
-
-## Special Cases
-
-### Rust Version / Crate Info
-```
-User: "What's new in latest Rust" / "tokio latest version"
--> Invoke: rust-learner
--> Use agent: rust-changelog / crate-researcher
--> DO NOT use WebSearch
-```
-
-### Writing Rust Code
-```
-User: "Help me write an async HTTP server"
--> Invoke: rust-router (identify: async + web)
--> Invoke: m07-concurrency + domain-web
--> Check rust-learner for latest patterns
--> Write code
-```
-
-### Error Debugging
-```
-User: "How to fix E0382"
--> Invoke: rust-router (identify: ownership error)
--> Invoke: m01-ownership
--> Explain fix patterns
-```
-
-## Agent Priority
-
-After invoking skills, use these agents for live data:
-
-| Need | Agent |
-|------|-------|
-| Rust release info | rust-changelog |
-| Crate version/info | crate-researcher |
-| API documentation | docs-researcher |
-| Clippy lint details | clippy-researcher |
-
-**Fallback to WebSearch ONLY if all agents fail.**
-
-## Default Project Settings
-
-When creating new Rust projects or Cargo.toml files, use these defaults:
-
-```toml
-[package]
-edition = "2024"  # ALWAYS use latest stable edition
-rust-version = "1.85"  # Minimum supported Rust version
-
-[lints.rust]
-unsafe_code = "warn"
-
-[lints.clippy]
-all = "warn"
-pedantic = "warn"
-```
-
-**Rules:**
-- ALWAYS use `edition = "2024"` (not 2021 or earlier)
-- Include `rust-version` for MSRV clarity
-- Enable clippy lints by default
+Use the shared defaults from [`_meta/platform-behavior-contract.md`](_meta/platform-behavior-contract.md#shared-rust-defaults).

--- a/_meta/platform-behavior-contract.md
+++ b/_meta/platform-behavior-contract.md
@@ -76,11 +76,13 @@ Typical use cases:
 
 Use the same skill routing and reasoning contract, but execute directly with the tools available on the current platform when agent infrastructure is unavailable.
 
-Inline mode should preserve:
+Inline mode should aim to preserve:
 - routing behavior
 - negotiation behavior
 - domain-aware analysis
 - live-data fetching priority where possible
+
+Actual behavior depends on the platform's available tools. If live retrieval is unavailable, the response should disclose that limitation instead of implying full parity.
 
 ## Output Contract
 
@@ -100,6 +102,22 @@ When negotiation is enabled, answers should include:
 - confidence
 - gaps or missing data
 - final recommendation
+
+Suggested structure:
+
+```markdown
+## Negotiation Analysis
+
+**Query Type:** [Comparative | Cross-domain | Synthesis | Ambiguous]
+**Negotiation:** Enabled
+
+### Source Assessment
+- **Confidence:** HIGH | MEDIUM | LOW | UNCERTAIN
+- **Gaps:** [What is still missing]
+
+## Synthesized Answer
+[Recommendation]
+```
 
 ### Live Data Responses
 

--- a/_meta/platform-behavior-contract.md
+++ b/_meta/platform-behavior-contract.md
@@ -1,0 +1,151 @@
+# Cross-Platform Rust Behavior Contract
+
+> Shared behavior contract for Claude Code, Codex, and compatible agents.
+> This document defines **what** Rust Skills should do across platforms.
+> Platform-specific files define **how** that behavior is enforced.
+
+## Purpose
+
+Use this contract to keep `CLAUDE.md`, `AGENTS.md`, hooks, and skill routing aligned.
+
+The goal is **behavior parity**, not identical runtime capabilities.
+
+## Required Shared Workflow
+
+### 1. Route Through `rust-router` First
+
+For any Rust-related question, start with `rust-router` before loading specialized skills.
+
+This includes:
+- compiler errors such as `E0xxx`
+- design questions
+- crate or ecosystem questions
+- code-writing requests in Rust
+- any question asked inside a Rust project context
+
+### 2. Enable Negotiation When Scope Is Comparative or Ambiguous
+
+Negotiation is required when the prompt includes:
+- comparison language such as `compare`, `vs`, `difference`, `best practice`
+- domain keyword + compiler/runtime problem
+- two or more technologies that need trade-off analysis
+- ambiguous synthesis requests
+
+When negotiation is enabled, the response should surface:
+- confidence level
+- notable gaps
+- synthesized recommendation
+
+### 3. Use Dual-Skill Loading for Domain-Qualified Problems
+
+When a prompt contains both:
+- a Layer 1 / Layer 2 problem signal
+- and a domain signal
+
+load both:
+- the mechanics or design skill
+- the relevant `domain-*` skill
+
+Examples:
+- `Web API` + `Send` error -> `m07-concurrency` + `domain-web`
+- `trading` + `E0382` -> `m01-ownership` + `domain-fintech`
+
+### 4. Route Live Data Requests Through `rust-learner`
+
+Use `rust-learner` for:
+- Rust versions and release features
+- crate versions and metadata
+- API documentation lookups
+- Clippy lint lookups
+
+When live information tools are available, do not answer these from memory.
+
+## Execution Modes
+
+### Agent Mode
+
+Use background agents, tasks, or equivalent runtime helpers when the platform supports them and the repository ships the needed agent files.
+
+Typical use cases:
+- version lookups
+- crate metadata
+- docs fetching
+- parallel analysis helpers
+
+### Inline Mode
+
+Use the same skill routing and reasoning contract, but execute directly with the tools available on the current platform when agent infrastructure is unavailable.
+
+Inline mode should preserve:
+- routing behavior
+- negotiation behavior
+- domain-aware analysis
+- live-data fetching priority where possible
+
+## Output Contract
+
+### Problem Solving / Troubleshooting
+
+For compiler errors, design issues, and domain-qualified Rust problems, answers should include:
+- the entry problem or error
+- the relevant domain or design constraint when applicable
+- the design decision that follows from that constraint
+
+This can be presented as a short reasoning chain.
+
+### Negotiation Responses
+
+When negotiation is enabled, answers should include:
+- query type or comparison framing
+- confidence
+- gaps or missing data
+- final recommendation
+
+### Live Data Responses
+
+For version, crate, and docs queries:
+- identify the source or retrieval path when possible
+- avoid unsupported guesses when a live source is available
+- make fallback behavior explicit when live tools are missing
+
+## Platform Adapters
+
+### Claude Code
+
+Claude Code may enforce this contract proactively through plugin hooks and runtime injection.
+
+Platform-specific instructions live in:
+- [`CLAUDE.md`](../CLAUDE.md)
+- hook files under `.claude/`
+
+### Codex and Compatible Agents
+
+Codex does not have the Claude plugin hook model. It should still follow the same contract by making the workflow explicit in:
+- [`AGENTS.md`](../AGENTS.md)
+- [`.codex/INSTALL.md`](../.codex/INSTALL.md)
+
+## Shared Rust Defaults
+
+When creating Rust projects or `Cargo.toml` files, prefer:
+
+```toml
+[package]
+edition = "2024"
+rust-version = "1.85"
+
+[lints.rust]
+unsafe_code = "warn"
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"
+```
+
+## Non-Goals
+
+This contract does not promise:
+- identical tool APIs on every platform
+- automatic hook behavior outside Claude Code
+- equal levels of runtime enforcement
+
+It does require the same reasoning model and routing intent everywhere.

--- a/tests/README.md
+++ b/tests/README.md
@@ -113,6 +113,12 @@ claude -p "tokio 最新版本"                # rust-learner
 - negotiation parity
 - `Agent Mode` vs `Inline Mode` expectations
 
+Manual parity prompts:
+- `E0382 use of moved value`
+- `Web API config sharing error: Rc cannot be sent`
+- `compare tokio vs async-std`
+- `What's the latest version of tokio?`
+
 ## Coverage Summary
 
 | Category | Skills | Tested |

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,7 @@ tests/
 │   ├── domain-skills.md    # Layer 3 domain skills
 │   ├── unsafe.md           # unsafe-checker tests
 │   ├── routing.md          # rust-router tests
+│   ├── platform-parity.md  # Claude/Codex behavior parity tests
 │   └── agents.md           # Agent integration tests
 │
 ├── pressure-scenarios/     # Edge case tests
@@ -105,6 +106,12 @@ claude -p "tokio 最新版本"                # rust-learner
 - rust-changelog
 - docs-researcher
 - clippy-researcher
+
+### 6. Cross-Platform Parity
+- Claude Code and Codex adapter behavior
+- shared routing expectations
+- negotiation parity
+- `Agent Mode` vs `Inline Mode` expectations
 
 ## Coverage Summary
 

--- a/tests/scenarios/platform-parity.md
+++ b/tests/scenarios/platform-parity.md
@@ -1,0 +1,68 @@
+# Cross-Platform Parity Scenarios
+
+These scenarios validate the intended behavior parity between Claude Code and Codex.
+
+The platforms do not share the same runtime enforcement model. They should still follow the same behavior contract from [`_meta/platform-behavior-contract.md`](../../_meta/platform-behavior-contract.md).
+
+## Scenario 1: Compiler Error Routing
+
+**Prompt:** `E0382 use of moved value`
+
+**Expected Shared Behavior:**
+- Route through `rust-router` first
+- Identify Layer 1 ownership problem
+- Load `m01-ownership`
+
+**Expected Response Elements:**
+- problem framing for the moved-value error
+- ownership-oriented explanation
+- context-aware fix patterns instead of a blind surface answer
+
+## Scenario 2: Domain + Error Dual Loading
+
+**Prompt:** `Web API config sharing error: Rc cannot be sent`
+
+**Expected Shared Behavior:**
+- Route through `rust-router` first
+- Detect concurrency issue
+- Detect web domain context
+- Load both `m07-concurrency` and `domain-web`
+
+**Expected Response Elements:**
+- reasoning chain or equivalent structure
+- explicit domain constraint for web handlers
+- design recommendation that reflects the domain
+
+## Scenario 3: Negotiation Query
+
+**Prompt:** `compare tokio vs async-std`
+
+**Expected Shared Behavior:**
+- Route through `rust-router` first
+- Enable negotiation flow before specialized crate discussion
+
+**Expected Response Elements:**
+- comparison framing
+- confidence and gaps
+- synthesized recommendation instead of isolated facts
+
+## Scenario 4: Live Rust Data Query
+
+**Prompt:** `What's the latest version of tokio?`
+
+**Expected Shared Behavior:**
+- Route live-data handling through `rust-learner`
+- Prefer `Agent Mode` when supported
+- Fall back to `Inline Mode` when agents are unavailable
+
+**Expected Response Elements:**
+- clear crate/version answer
+- retrieval path or source awareness when available
+- no unsupported answer from memory when live retrieval exists
+
+## Review Checklist
+
+- [ ] Claude and Codex reference the same shared contract
+- [ ] Codex guidance documents the lack of hooks without changing the workflow
+- [ ] Claude guidance focuses on hook-based enforcement, not duplicated core logic
+- [ ] The four scenarios remain valid under both platform adapters


### PR DESCRIPTION
## Summary

- add a shared cross-platform Rust behavior contract in `_meta/platform-behavior-contract.md`
- realign `AGENTS.md` and `CLAUDE.md` around the same routing, negotiation, and live-data expectations
- keep the documented minimal Codex install viable by restoring standalone quick-reference guidance in `AGENTS.md`
- clarify Codex parity limits in `.codex/INSTALL.md`
- add a cross-platform parity scenario in `tests/scenarios/platform-parity.md` and reference it from `tests/README.md`

## Why

Claude Code currently gets stronger enforcement through hooks and plugin runtime behavior, while Codex relies mostly on static guidance. This patch does not try to recreate Claude hooks in Codex. Instead, it reduces behavior drift by making the intended Rust workflow explicit and shared across both adapters.

The follow-up commit also preserves the documented `copy AGENTS.md only` path by keeping a compact standalone quick reference in `AGENTS.md`, and it narrows parity claims so the docs do not over-promise runtime equivalence.

## Scope

This change is limited to cross-platform behavior documentation and test scenarios:

- `.codex/INSTALL.md`
- `AGENTS.md`
- `CLAUDE.md`
- `_meta/platform-behavior-contract.md`
- `tests/README.md`
- `tests/scenarios/platform-parity.md`

It does not change Claude hooks, plugin manifests, or agent runtime files.

## Validation

Local checks:

- `git diff --check`
- `python3 tests/hook-matcher-test.py`

Manual A/B protocol on 4 prompts:

- `E0382 use of moved value`
- `Web API config sharing error: Rc cannot be sent`
- `compare tokio vs async-std`
- `What's the latest version of tokio?`

Observed result from the sampled prompts:

- no clear Claude regression
- clearer Codex alignment on routing, negotiation, and live-data behavior
- measurable Codex improvement on 3 of 4 sampled prompts

## Notes

I did not use `tests/validation/validate-skills.sh` as a pass/fail gate for this patch because it already reports unrelated pre-existing repository issues on `main`.
