### PR TITLE
fix: validate internal skill frontmatter

### DIFF
--- a/skills/core-actionbook/SKILL.md
+++ b/skills/core-actionbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: core-actionbook
 description: "Internal: pre-computed action selectors used by rust-learner agents."
-# Internal tool - no description to prevent auto-triggering
+# Internal helper: keep a low-trigger description for schema validity; use explicit routing from parent skills.
 # Used by: rust-learner agents for pre-computed selectors
 ---
 

--- a/skills/core-actionbook/SKILL.md
+++ b/skills/core-actionbook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: core-actionbook
-description: Internal: pre-computed action selectors used by rust-learner agents.
+description: "Internal: pre-computed action selectors used by rust-learner agents."
 # Internal tool - no description to prevent auto-triggering
 # Used by: rust-learner agents for pre-computed selectors
 ---

--- a/skills/core-actionbook/SKILL.md
+++ b/skills/core-actionbook/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: core-actionbook
+description: Internal: pre-computed action selectors used by rust-learner agents.
 # Internal tool - no description to prevent auto-triggering
 # Used by: rust-learner agents for pre-computed selectors
 ---

--- a/skills/core-agent-browser/SKILL.md
+++ b/skills/core-agent-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: core-agent-browser
-description: Internal: browser-based documentation fetcher used by rust-learner and researcher agents.
+description: "Internal: browser-based documentation fetcher used by rust-learner and researcher agents."
 # Internal tool - no description to prevent auto-triggering
 # Used by: rust-learner, docs-researcher, crate-researcher agents
 ---

--- a/skills/core-agent-browser/SKILL.md
+++ b/skills/core-agent-browser/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: core-agent-browser
+description: Internal: browser-based documentation fetcher used by rust-learner and researcher agents.
 # Internal tool - no description to prevent auto-triggering
 # Used by: rust-learner, docs-researcher, crate-researcher agents
 ---

--- a/skills/core-agent-browser/SKILL.md
+++ b/skills/core-agent-browser/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: core-agent-browser
 description: "Internal: browser-based documentation fetcher used by rust-learner and researcher agents."
-# Internal tool - no description to prevent auto-triggering
+# Internal helper: keep a low-trigger description for schema validity; use explicit routing from parent skills.
 # Used by: rust-learner, docs-researcher, crate-researcher agents
 ---
 

--- a/skills/core-dynamic-skills/SKILL.md
+++ b/skills/core-dynamic-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: core-dynamic-skills
 description: "Internal: sync, clean, or update dynamic crate skills. Triggered by slash commands only."
-# Command-based tool - no description to prevent auto-triggering
+# Command-based tool: keep a low-trigger description for schema validity; operational entrypoints are explicit slash commands.
 # Triggered by: /sync-crate-skills, /clean-crate-skills, /update-crate-skill
 argument-hint: "[--force] | <crate_name>"
 context: fork

--- a/skills/core-dynamic-skills/SKILL.md
+++ b/skills/core-dynamic-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: core-dynamic-skills
-description: Internal: sync, clean, or update dynamic crate skills. Triggered by slash commands only.
+description: "Internal: sync, clean, or update dynamic crate skills. Triggered by slash commands only."
 # Command-based tool - no description to prevent auto-triggering
 # Triggered by: /sync-crate-skills, /clean-crate-skills, /update-crate-skill
 argument-hint: "[--force] | <crate_name>"

--- a/skills/core-dynamic-skills/SKILL.md
+++ b/skills/core-dynamic-skills/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: core-dynamic-skills
+description: Internal: sync, clean, or update dynamic crate skills. Triggered by slash commands only.
 # Command-based tool - no description to prevent auto-triggering
 # Triggered by: /sync-crate-skills, /clean-crate-skills, /update-crate-skill
 argument-hint: "[--force] | <crate_name>"

--- a/skills/core-fix-skill-docs/SKILL.md
+++ b/skills/core-fix-skill-docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: core-fix-skill-docs
-description: Internal: check and fix missing reference files in dynamic skills. Triggered by slash command only.
+description: "Internal: check and fix missing reference files in dynamic skills. Triggered by slash command only."
 # Internal maintenance tool - no description to prevent auto-triggering
 # Triggered by: /fix-skill-docs command
 argument-hint: "[crate_name] [--check-only]"

--- a/skills/core-fix-skill-docs/SKILL.md
+++ b/skills/core-fix-skill-docs/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: core-fix-skill-docs
+description: Internal: check and fix missing reference files in dynamic skills. Triggered by slash command only.
 # Internal maintenance tool - no description to prevent auto-triggering
 # Triggered by: /fix-skill-docs command
 argument-hint: "[crate_name] [--check-only]"

--- a/skills/core-fix-skill-docs/SKILL.md
+++ b/skills/core-fix-skill-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: core-fix-skill-docs
 description: "Internal: check and fix missing reference files in dynamic skills. Triggered by slash command only."
-# Internal maintenance tool - no description to prevent auto-triggering
+# Internal maintenance tool: keep a low-trigger description for schema validity; operational entrypoint is the slash command.
 # Triggered by: /fix-skill-docs command
 argument-hint: "[crate_name] [--check-only]"
 context: fork

--- a/tests/README.md
+++ b/tests/README.md
@@ -66,7 +66,8 @@ claude -p "tokio 最新版本"                # rust-learner
 ./tests/validation/validate-skill-frontmatter.sh
 ```
 
-The validation script scans every `skills/**/SKILL.md` file and fails if required frontmatter such as `name` or `description` is missing.
+- `validate-skills.sh` runs the broader repository validation suite and delegates skill frontmatter checks to the focused validator.
+- `validate-skill-frontmatter.sh` parses every `skills/**/SKILL.md` frontmatter block as YAML and requires non-empty `name` and `description` fields.
 
 ## Test Categories
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,7 +63,10 @@ claude -p "tokio 最新版本"                # rust-learner
 
 ```bash
 ./tests/validation/validate-skills.sh
+./tests/validation/validate-skill-frontmatter.sh
 ```
+
+The validation script scans every `skills/**/SKILL.md` file and fails if required frontmatter such as `name` or `description` is missing.
 
 ## Test Categories
 

--- a/tests/validation/validate-skill-frontmatter.sh
+++ b/tests/validation/validate-skill-frontmatter.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Validate that every skill declares required frontmatter fields.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+FAILED=0
+COUNT=0
+
+echo "======================================"
+echo "Rust Skills Frontmatter Validation"
+echo "======================================"
+echo ""
+
+while IFS= read -r -d '' skill_file; do
+    COUNT=$((COUNT + 1))
+    relative_file="${skill_file#"$ROOT_DIR"/}"
+
+    if ! grep -q "^name:" "$skill_file"; then
+        echo "FAIL: $relative_file missing name:"
+        FAILED=1
+    fi
+
+    if ! grep -q "^description:" "$skill_file"; then
+        echo "FAIL: $relative_file missing description:"
+        FAILED=1
+    fi
+done < <(find "$ROOT_DIR/skills" -name "SKILL.md" -type f -print0)
+
+if [ "$COUNT" -eq 0 ]; then
+    echo "FAIL: no SKILL.md files found under skills/"
+    exit 1
+fi
+
+if [ "$FAILED" -ne 0 ]; then
+    echo ""
+    echo "Frontmatter validation FAILED"
+    exit 1
+fi
+
+echo "Validated $COUNT skill files."
+echo "Frontmatter validation PASSED"

--- a/tests/validation/validate-skill-frontmatter.sh
+++ b/tests/validation/validate-skill-frontmatter.sh
@@ -9,6 +9,11 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
 FAILED=0
 COUNT=0
 
+if ! command -v ruby >/dev/null 2>&1; then
+    echo "FAIL: ruby is required to parse SKILL.md frontmatter"
+    exit 1
+fi
+
 echo "======================================"
 echo "Rust Skills Frontmatter Validation"
 echo "======================================"
@@ -18,20 +23,25 @@ while IFS= read -r -d '' skill_file; do
     COUNT=$((COUNT + 1))
     relative_file="${skill_file#"$ROOT_DIR"/}"
 
-    if ! ruby -e '
+    if ! error_output=$(ruby -e '
         require "yaml"
         path = ARGV.fetch(0)
-        text = File.read(path)
-        parts = text.split(/^---\s*$\n?/, 3)
-        raise "missing frontmatter delimiters" if parts.length < 3
-        data = YAML.safe_load(parts[1], permitted_classes: [], aliases: false)
-        raise "frontmatter must be a mapping" unless data.is_a?(Hash)
-        %w[name description].each do |key|
-          value = data[key]
-          raise "missing #{key}" if value.nil? || value.to_s.strip.empty?
+        begin
+          text = File.read(path)
+          parts = text.split(/^---\s*$\n?/, 3)
+          raise "missing frontmatter delimiters" if parts.length < 3
+          data = YAML.safe_load(parts[1], permitted_classes: [], aliases: false)
+          raise "frontmatter must be a mapping" unless data.is_a?(Hash)
+          %w[name description].each do |key|
+            value = data[key]
+            raise "missing #{key}" if value.nil? || value.to_s.strip.empty?
+          end
+        rescue StandardError => e
+          warn e.message
+          exit 1
         end
-      ' "$skill_file" >/dev/null 2>&1; then
-        echo "FAIL: $relative_file has invalid or incomplete YAML frontmatter"
+      ' "$skill_file" 2>&1); then
+        echo "FAIL: $relative_file has invalid or incomplete YAML frontmatter: $error_output"
         FAILED=1
     fi
 done < <(find "$ROOT_DIR/skills" -name "SKILL.md" -type f -print0)

--- a/tests/validation/validate-skill-frontmatter.sh
+++ b/tests/validation/validate-skill-frontmatter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Validate that every skill declares required frontmatter fields.
+# Validate that every skill declares required frontmatter fields and parses as YAML.
 
 set -euo pipefail
 
@@ -18,13 +18,20 @@ while IFS= read -r -d '' skill_file; do
     COUNT=$((COUNT + 1))
     relative_file="${skill_file#"$ROOT_DIR"/}"
 
-    if ! grep -q "^name:" "$skill_file"; then
-        echo "FAIL: $relative_file missing name:"
-        FAILED=1
-    fi
-
-    if ! grep -q "^description:" "$skill_file"; then
-        echo "FAIL: $relative_file missing description:"
+    if ! ruby -e '
+        require "yaml"
+        path = ARGV.fetch(0)
+        text = File.read(path)
+        parts = text.split(/^---\s*$\n?/, 3)
+        raise "missing frontmatter delimiters" if parts.length < 3
+        data = YAML.safe_load(parts[1], permitted_classes: [], aliases: false)
+        raise "frontmatter must be a mapping" unless data.is_a?(Hash)
+        %w[name description].each do |key|
+          value = data[key]
+          raise "missing #{key}" if value.nil? || value.to_s.strip.empty?
+        end
+      ' "$skill_file" >/dev/null 2>&1; then
+        echo "FAIL: $relative_file has invalid or incomplete YAML frontmatter"
         FAILED=1
     fi
 done < <(find "$ROOT_DIR/skills" -name "SKILL.md" -type f -print0)

--- a/tests/validation/validate-skills.sh
+++ b/tests/validation/validate-skills.sh
@@ -70,28 +70,22 @@ echo ""
 # =====================================
 echo "Checking SKILL.md files..."
 
-skill_files=(
-    "skills/m01-ownership/SKILL.md"
-    "skills/m06-error-handling/SKILL.md"
-    "skills/m07-concurrency/SKILL.md"
-    "skills/unsafe-checker/SKILL.md"
-    "skills/coding-guidelines/SKILL.md"
-    "skills/rust-router/SKILL.md"
-    "skills/rust-learner/SKILL.md"
-)
+skill_count=0
 
-for file in "${skill_files[@]}"; do
-    if [ -f "$ROOT_DIR/$file" ]; then
-        # Check for required frontmatter
-        if grep -q "^name:" "$ROOT_DIR/$file" && grep -q "^description:" "$ROOT_DIR/$file"; then
-            pass "$file valid"
-        else
-            fail "$file missing frontmatter"
-        fi
+while IFS= read -r -d '' skill_file; do
+    skill_count=$((skill_count + 1))
+    relative_file="${skill_file#"$ROOT_DIR"/}"
+
+    if grep -q "^name:" "$skill_file" && grep -q "^description:" "$skill_file"; then
+        pass "$relative_file valid"
     else
-        fail "$file missing"
+        fail "$relative_file missing required frontmatter"
     fi
-done
+done < <(find "$ROOT_DIR/skills" -name "SKILL.md" -type f -print0)
+
+if [ "$skill_count" -eq 0 ]; then
+    fail "No SKILL.md files found under skills/"
+fi
 
 echo ""
 

--- a/tests/validation/validate-skills.sh
+++ b/tests/validation/validate-skills.sh
@@ -70,21 +70,14 @@ echo ""
 # =====================================
 echo "Checking SKILL.md files..."
 
-skill_count=0
-
-while IFS= read -r -d '' skill_file; do
-    skill_count=$((skill_count + 1))
-    relative_file="${skill_file#"$ROOT_DIR"/}"
-
-    if grep -q "^name:" "$skill_file" && grep -q "^description:" "$skill_file"; then
-        pass "$relative_file valid"
-    else
-        fail "$relative_file missing required frontmatter"
-    fi
-done < <(find "$ROOT_DIR/skills" -name "SKILL.md" -type f -print0)
+skill_count=$(find "$ROOT_DIR/skills" -name "SKILL.md" -type f | wc -l | tr -d ' ')
 
 if [ "$skill_count" -eq 0 ]; then
     fail "No SKILL.md files found under skills/"
+elif "$SCRIPT_DIR/validate-skill-frontmatter.sh"; then
+    pass "Validated frontmatter for $skill_count skill files"
+else
+    fail "skills/**/SKILL.md frontmatter validation failed"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- add missing `description` frontmatter to four internal skills used by the plugin bundle
- broaden the existing skill validation script so it scans every `skills/**/SKILL.md`
- add a focused frontmatter validator that parses YAML instead of only grepping for keys

## Why
Codex skipped four installed skills because their `SKILL.md` frontmatter omitted `description`. The first local repair added `description` values, but unquoted `Internal: ...` scalars are invalid YAML, so the runtime loader still rejected them. This patch fixes both problems at the source and adds a parser-based guard so invalid YAML frontmatter fails before release.

## Verification
- `bash tests/validation/validate-skill-frontmatter.sh`
- `find skills -name SKILL.md -print0 | xargs -0 grep -L '^description:'`

## Notes
- `tests/validation/validate-skills.sh` still reports unrelated pre-existing `agents/*.md` `tools:` metadata issues. I left those out of this patch.
