### PR TITLE
Fix Codex skill loading warnings

### DIFF
--- a/skills/core-actionbook/SKILL.md
+++ b/skills/core-actionbook/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: core-actionbook
-# Internal tool - no description to prevent auto-triggering
-# Used by: rust-learner agents for pre-computed selectors
+description: "Internal support skill for actionbook MCP selectors used by Rust documentation research workflows. Use only when another rust-skills workflow explicitly requests actionbook-backed selectors."
+user-invocable: false
+disable-model-invocation: true
 ---
 
 # Actionbook

--- a/skills/core-actionbook/agents/openai.yaml
+++ b/skills/core-actionbook/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/skills/core-agent-browser/SKILL.md
+++ b/skills/core-agent-browser/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: core-agent-browser
-# Internal tool - no description to prevent auto-triggering
-# Used by: rust-learner, docs-researcher, crate-researcher agents
+description: "Internal support skill for agent-browser CLI workflows used by rust-learner, docs-researcher, and crate-researcher. Use only when browser automation is explicitly required."
+user-invocable: false
+disable-model-invocation: true
 ---
 
 # Browser Automation with agent-browser

--- a/skills/core-agent-browser/agents/openai.yaml
+++ b/skills/core-agent-browser/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/skills/core-dynamic-skills/SKILL.md
+++ b/skills/core-dynamic-skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: core-dynamic-skills
-# Command-based tool - no description to prevent auto-triggering
-# Triggered by: /sync-crate-skills, /clean-crate-skills, /update-crate-skill
+description: "Internal command support for dynamic Rust crate skill management. Use only when explicitly invoked by /sync-crate-skills, /clean-crate-skills, or /update-crate-skill."
+disable-model-invocation: true
 argument-hint: "[--force] | <crate_name>"
 context: fork
 agent: general-purpose

--- a/skills/core-dynamic-skills/agents/openai.yaml
+++ b/skills/core-dynamic-skills/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/skills/core-fix-skill-docs/SKILL.md
+++ b/skills/core-fix-skill-docs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: core-fix-skill-docs
-# Internal maintenance tool - no description to prevent auto-triggering
-# Triggered by: /fix-skill-docs command
+description: "Internal maintenance support for checking and fixing generated Rust skill documentation references. Use only when explicitly invoked by /fix-skill-docs."
+disable-model-invocation: true
 argument-hint: "[crate_name] [--check-only]"
 context: fork
 agent: general-purpose

--- a/skills/core-fix-skill-docs/agents/openai.yaml
+++ b/skills/core-fix-skill-docs/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## Summary

- Fix Codex skill loading warnings for internal core skills
- Add Codex invocation policy to keep internal skills out of implicit invocation
- Keep internal support skills non-triggerable on Claude runtimes

## Testing

- `python3 tests/hook-matcher-test.py`
- Verified Codex skill loading with installed skills
- Verified Claude plugin loading with an isolated fixture
