### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #37)

### DIFF
--- a/commands/achievement.md
+++ b/commands/achievement.md
@@ -1,6 +1,6 @@
 ---
 description: View coding achievements, stats, and progress
-argument-hint: [list|stats|reset] [--category bug|test|streak|safety|learning]
+argument-hint: "[list|stats|reset] [--category bug|test|streak|safety|learning]"
 ---
 
 # Achievement System

--- a/commands/ai-daily.md
+++ b/commands/ai-daily.md
@@ -1,6 +1,6 @@
 ---
 description: Generate AI daily/weekly news report from Reddit communities
-argument-hint: [day|week|month] [--save [path]]
+argument-hint: "[day|week|month] [--save [path]]"
 ---
 
 # AI Daily Report

--- a/commands/cache-clean.md
+++ b/commands/cache-clean.md
@@ -1,6 +1,6 @@
 ---
 description: Clean Rust docs cache
-argument-hint: [--all | --expired | crate_name]
+argument-hint: "[--all | --expired | crate_name]"
 ---
 
 # Cache Clean

--- a/commands/cache-status.md
+++ b/commands/cache-status.md
@@ -1,6 +1,6 @@
 ---
 description: Show Rust docs cache status
-argument-hint: [--verbose]
+argument-hint: "[--verbose]"
 ---
 
 # Cache Status

--- a/commands/clean-crate-skills.md
+++ b/commands/clean-crate-skills.md
@@ -1,6 +1,6 @@
 ---
 description: Remove local dynamic crate skills
-argument-hint: [crate_names...] [--all]
+argument-hint: "[crate_names...] [--all]"
 ---
 
 # Clean Crate Skills

--- a/commands/create-llms-from-source.md
+++ b/commands/create-llms-from-source.md
@@ -1,6 +1,6 @@
 ---
 description: Generate llms.txt from local Rust source code
-argument-hint: [source_path] [output_path]
+argument-hint: "[source_path] [output_path]"
 ---
 
 # Create llms.txt from Rust Source Code

--- a/commands/fix-skill-docs.md
+++ b/commands/fix-skill-docs.md
@@ -1,6 +1,6 @@
 ---
 description: Check and fix missing reference files in dynamic skills
-argument-hint: [crate_name] [--check-only] [--remove-invalid]
+argument-hint: "[crate_name] [--check-only] [--remove-invalid]"
 ---
 
 # Fix Skill Documentation

--- a/commands/rust-daily.md
+++ b/commands/rust-daily.md
@@ -1,6 +1,6 @@
 ---
 description: Generate Rust daily/weekly/monthly news report
-argument-hint: [day|week|month] [--category ecosystem|official|foundation] [--save [path]]
+argument-hint: "[day|week|month] [--category ecosystem|official|foundation] [--save [path]]"
 ---
 
 # Rust Daily Report

--- a/commands/sync-crate-skills.md
+++ b/commands/sync-crate-skills.md
@@ -1,6 +1,6 @@
 ---
 description: Sync dynamic skills for Cargo.toml dependencies or local source
-argument-hint: [--force] [--from-source <path>] [crate_names...]
+argument-hint: "[--force] [--from-source <path>] [crate_names...]"
 ---
 
 # Sync Crate Skills


### PR DESCRIPTION
Closes #37.

## Summary

Purely mechanical single-character transform to 9 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (9)

- `commands/cache-status.md`
- `commands/cache-clean.md`
- `commands/sync-crate-skills.md`
- `commands/clean-crate-skills.md`
- `commands/fix-skill-docs.md`
- `commands/achievement.md`
- `commands/ai-daily.md`
- `commands/rust-daily.md`
- `commands/create-llms-from-source.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
